### PR TITLE
Upgrade react-native-nitro-palette to version 1.1.1 and update build configurations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "react-native-nitro-palette": {
       "name": "react-native-nitro-palette",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@shopify/react-native-skia": "^1.12.4",

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -105,6 +105,15 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {
@@ -116,4 +125,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+    
+    implementation project(":react-native-nitro-palette")
+    
+    implementation project(":react-native-nitro-modules")
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,18 +3,19 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
-        ndkVersion = "26.1.10909125"
-        kotlinVersion = "1.9.24"
+        targetSdkVersion = 35
+        ndkVersion = "27.1.12297006"
+        kotlinVersion = "2.0.21"
+        agpVersion = "8.8.2"
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:${agpVersion}")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -15,12 +15,13 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+android.enableJetifier=true
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
@@ -37,3 +38,8 @@ newArchEnabled=true
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# 依存関係解決の問題を解決するための追加設定
+android.nonTransitiveRClass=true
+org.gradle.configureondemand=true
+org.gradle.caching=true

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,6 +1,11 @@
 pluginManagement { includeBuild("../../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> 
+    ex.autolinkLibrariesFromCommand()
+}
 rootProject.name = 'NitroExample'
 include ':app'
 includeBuild('../../node_modules/@react-native/gradle-plugin')
+
+include ':react-native-nitro-palette'
+project(':react-native-nitro-palette').projectDir = new File(rootProject.projectDir, '../../react-native-nitro-palette/android')

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NitroPalette (1.1.0):
+  - NitroPalette (1.1.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1978,7 +1978,7 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: c32f2e405098bc1ebe30630a051ddce6f21d3c2e
   NitroModules: 9971afee433c04d492fc035941c67dfc68b1f45e
-  NitroPalette: bed680cbdd55aae7272e90fe1678f296e9c7917a
+  NitroPalette: fe7d9335e92e9f7343480736b88878dd7e66e4fc
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 0ada4fb1e5c5637bff940dc40b94e2d3bf96b0ab
   RCTRequired: 76ca80ff10acb3834ed0dacba9645645009578a2

--- a/react-native-nitro-palette/android/build.gradle
+++ b/react-native-nitro-palette/android/build.gradle
@@ -5,7 +5,8 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
+    classpath "com.android.tools.build:gradle:8.8.2"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
   }
 }
 
@@ -71,22 +72,22 @@ android {
 
   packagingOptions {
     excludes = [
-            "META-INF",
-            "META-INF/**",
-            "**/libc++_shared.so",
-            "**/libfbjni.so",
-            "**/libjsi.so",
-            "**/libfolly_json.so",
-            "**/libfolly_runtime.so",
-            "**/libglog.so",
-            "**/libhermes.so",
-            "**/libhermes-executor-debug.so",
-            "**/libhermes_executor.so",
-            "**/libreactnative.so",
-            "**/libreactnativejni.so",
-            "**/libturbomodulejsijni.so",
-            "**/libreact_nativemodule_core.so",
-            "**/libjscexecutor.so"
+        "META-INF",
+        "META-INF/**",
+        "**/libc++_shared.so",
+        "**/libfbjni.so",
+        "**/libjsi.so",
+        "**/libfolly_json.so",
+        "**/libfolly_runtime.so",
+        "**/libglog.so",
+        "**/libhermes.so",
+        "**/libhermes-executor-debug.so",
+        "**/libhermes_executor.so",
+        "**/libreactnative.so",
+        "**/libreactnativejni.so",
+        "**/libturbomodulejsijni.so",
+        "**/libreact_nativemodule_core.so",
+        "**/libjscexecutor.so"
     ]
   }
 
@@ -96,6 +97,9 @@ android {
   }
 
   buildTypes {
+    debug {
+      minifyEnabled false
+    }
     release {
       minifyEnabled false
     }
@@ -106,8 +110,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
   }
 
   sourceSets {
@@ -122,11 +130,21 @@ android {
   }
 }
 
+configurations {
+    implementation {
+        canBeResolved = true
+        canBeConsumed = true
+    }
+    api {
+        canBeResolved = true
+        canBeConsumed = true
+    }
+}
+
 repositories {
   mavenCentral()
   google()
 }
-
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -138,3 +156,10 @@ dependencies {
   implementation project(":react-native-nitro-modules")
 }
 
+if (isNewArchitectureEnabled()) {
+  react {
+    jsRootDir = file("../src/")
+    libraryName = "NitroPalette"
+    codegenJavaPackageName = "com.nitropalette"
+  }
+}

--- a/react-native-nitro-palette/android/gradle.properties
+++ b/react-native-nitro-palette/android/gradle.properties
@@ -1,5 +1,5 @@
-NitroPalette_kotlinVersion=1.9.24
+NitroPalette_kotlinVersion=2.0.21
 NitroPalette_minSdkVersion=23
 NitroPalette_targetSdkVersion=34
 NitroPalette_compileSdkVersion=34
-NitroPalette_ndkVersion=26.1.10909125
+NitroPalette_ndkVersion=27.1.12297006

--- a/react-native-nitro-palette/android/src/main/java/com/nitropalette/NitroPalettePackage.java
+++ b/react-native-nitro-palette/android/src/main/java/com/nitropalette/NitroPalettePackage.java
@@ -1,14 +1,15 @@
 package com.nitropalette;
 
 import android.util.Log;
-
 import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.TurboReactPackage;
 import com.margelo.nitro.core.HybridObject;
+import com.margelo.nitro.nitropalette.NitroPaletteOnLoad;
 
 import java.util.HashMap;
 import java.util.function.Supplier;
@@ -16,15 +17,14 @@ import java.util.function.Supplier;
 public class NitroPalettePackage extends TurboReactPackage {
   @Nullable
   @Override
-  public NativeModule getModule(String name, ReactApplicationContext reactContext) {
+  public NativeModule getModule(@NonNull String name, @NonNull ReactApplicationContext reactContext) {
     return null;
   }
 
+  @NonNull
   @Override
   public ReactModuleInfoProvider getReactModuleInfoProvider() {
-    return () -> {
-        return new HashMap<>();
-    };
+    return HashMap::new;
   }
 
   static {

--- a/react-native-nitro-palette/nitro.json
+++ b/react-native-nitro-palette/nitro.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/patrickkabwe/create-nitro-module/refs/heads/main/assets/nitro-schema.json",
+  "$schema": "https://nitro.margelo.com/nitro.schema.json",
   "cxxNamespace": [
     "nitropalette"
   ],

--- a/react-native-nitro-palette/package.json
+++ b/react-native-nitro-palette/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-nitro-palette",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Nitro module package",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/module/index.js",


### PR DESCRIPTION
Upgrade the `react-native-nitro-palette` package to version 1.1.1 and adjust the build configurations to support newer SDK and Kotlin versions. This includes enhancements for compatibility and performance improvements.